### PR TITLE
Preserve the collapse parameter in the remaining recursive callsites without it

### DIFF
--- a/R/json.R
+++ b/R/json.R
@@ -71,7 +71,7 @@ setMethod("toJSON", "ANY",
              if(isS4(x)) {
                paste("{", paste(dQuote(slotNames(x)), sapply(slotNames(x),
                                                               function(id)
-                                                                 toJSON(slot(x, id), ..., .level = .level + 1L,
+                                                                 toJSON(slot(x, id), ..., .level = .level + 1L, collapse = collapse,
                                                                         .na = .na, .escapeEscapes = .escapeEscapes, asIs = asIs,
                                                                          .inf = .inf)),
                                  sep = ": ", collapse = ","),
@@ -79,7 +79,7 @@ setMethod("toJSON", "ANY",
              } else {
 #cat(class(x), "\n")
                if(is.language(x)) {
-                  return(toJSON(as.list(x), asIs = asIs, .inf = .inf, .na = .na))
+                  return(toJSON(as.list(x), asIs = asIs, .inf = .inf, .na = .na, collapse = collapse))
                   stop("No method for converting ", class(x), " to JSON")
                }
 
@@ -271,7 +271,7 @@ setMethod("toJSON", "list",
                 return(if(is.null(names(x))) "[]" else "{}")
              }
 
-             els = lapply(x, toJSON, ..., .level = .level + 1L, .na = .na, .escapeEscapes = .escapeEscapes, asIs = asIs, .inf = .inf)
+             els = lapply(x, toJSON, ..., .level = .level + 1L, .na = .na, .escapeEscapes = .escapeEscapes, asIs = asIs, .inf = .inf, collapse = collapse)
 
              if(all(sapply(els, is.name)))
                names(els) = NULL

--- a/tests/collapse.R
+++ b/tests/collapse.R
@@ -1,0 +1,4 @@
+library(RJSONIO)
+
+json = toJSON(list( foo = c( one = 1, two = 2 ), bar = c( three = 3, four = 4 )), collapse = "")
+stopifnot( !grep("\n", json) )


### PR DESCRIPTION
Two of the three callsites affected calls to toJSON() with the ANY
signature, but the most obvious defect was when calling toJSON() on a
list().

The test tries to serialize what could be thought of as a nested hash,
and fails if run on the code before this commit.
