### PR TITLE
Don't emit whitespace padding around numeric data

### DIFF
--- a/R/json.R
+++ b/R/json.R
@@ -169,7 +169,7 @@ setMethod("toJSON", "numeric",
             if(any(is.infinite(x)))
               warning("non-fininte values in numeric vector may not be approriately represented in JSON")             
 
-             tmp = formatC(x, digits = digits)
+             tmp = formatC(x, digits = digits, width = 1)
               
              if(any(nas <- is.na(x)))
                  tmp[nas] = .na


### PR DESCRIPTION
Without this change, this is the behavior you get:

```
> RJSONIO::toJSON(head(cars, 3), digits = 12)
[1] "{\n \"speed\": [             4,             4,             7 ],\n\"dist\": [             2,            10,             4 ] \n}"
```

With this change:

```
> RJSONIO::toJSON(head(cars, 3), digits = 12)
[1] "{\n \"speed\": [ 4, 4, 7 ],\n\"dist\": [ 2, 10, 4 ] \n}"
```

The space savings are significant for many uses of Shiny and htmlwidgets.