### PR TITLE
Added #include <stdint.h> to JSONWorker.cpp so that it builds on Ubuntu.

### DIFF
--- a/src/libjson/Source/JSONWorker.cpp
+++ b/src/libjson/Source/JSONWorker.cpp
@@ -1,3 +1,4 @@
+#include <stdint.h>
 #include "JSONWorker.h"
 
 bool used_ascii_one = false;  //used to know whether or not to check for intermediates when writing, once flipped, can't be unflipped


### PR DESCRIPTION
Added inclusion of a stdint.h so that package builds on Ubuntu. This resolves issues #23 and #17.
